### PR TITLE
directory for db added

### DIFF
--- a/src/api/db/file.md
+++ b/src/api/db/file.md
@@ -1,0 +1,1 @@
+**Added a db directory for all typeorm entities**


### PR DESCRIPTION
added an empty db directory for where all typeorm entities would be created to be exported to db.config.ts and also registered on the entities array. see ln 24 on "src/api/helpers/config/db.config.ts"